### PR TITLE
Update build configuration and README for typo

### DIFF
--- a/.github/workflows/Bulid.yml
+++ b/.github/workflows/Bulid.yml
@@ -35,26 +35,26 @@ jobs:
       - name: Build on Windows
         if: runner.os == 'Windows'
         run: |
-          pyinstaller --onefile --icon=sk.ico --add-data "CHT;CHT" --collect-all UnityPy --collect-all TypeTreeGeneratorAPI --collect-all archspec --name="SkilSong_CHT_win" sk_cht.py
+          pyinstaller --onefile --icon=sk.ico --add-data "CHT;CHT" --collect-all UnityPy --collect-all TypeTreeGeneratorAPI --collect-all archspec --name="SilkSong_CHT_win" sk_cht.py
       
       - name: Build on macOS
         if: runner.os == 'macOS'
         run: |
-          pyinstaller --onefile --icon=sk.icns --add-data "CHT:CHT" --collect-all UnityPy --collect-all TypeTreeGeneratorAPI --collect-all archspec --name="SkilSong_CHT_mac" sk_cht.py
+          pyinstaller --onefile --icon=sk.icns --add-data "CHT:CHT" --collect-all UnityPy --collect-all TypeTreeGeneratorAPI --collect-all archspec --name="SilkSong_CHT_mac" sk_cht.py
 
       - name: Build on Linux
         if: runner.os == 'Linux'
         run: |
-          pyinstaller --onefile --icon=sk.png --add-data "CHT:CHT" --collect-all UnityPy --collect-all TypeTreeGeneratorAPI --collect-all archspec --name="SkilSong_CHT_linux" sk_cht.py
+          pyinstaller --onefile --icon=sk.png --add-data "CHT:CHT" --collect-all UnityPy --collect-all TypeTreeGeneratorAPI --collect-all archspec --name="SilkSong_CHT_linux" sk_cht.py
 
       - name: Archive and Upload Artifact
         uses: actions/upload-artifact@v4
         with:
           name: executable-${{ runner.os }}
           path: |
-            dist/SkilSong_CHT_win.exe
-            dist/SkilSong_CHT_mac
-            dist/SkilSong_CHT_linux
+            dist/SilkSong_CHT_win.exe
+            dist/SilkSong_CHT_mac
+            dist/SilkSong_CHT_linux
           if-no-files-found: error
 
   release:
@@ -72,9 +72,9 @@ jobs:
       - name: Prepare Release Files
         run: |
           cd dist
-          find . -type f -name 'SkilSong_CHT_win.exe' -exec zip -j SkilSong_CHT-Windows.zip {} +
-          find . -type f -name 'SkilSong_CHT_mac' -exec zip -j SkilSong_CHT-macOS.zip {} +
-          find . -type f -name 'SkilSong_CHT_linux' -exec zip -j SkilSong_CHT-Linux.zip {} +
+          find . -type f -name 'SilkSong_CHT_win.exe' -exec zip -j SilkSong_CHT-Windows.zip {} +
+          find . -type f -name 'SilkSong_CHT_mac' -exec zip -j SilkSong_CHT-macOS.zip {} +
+          find . -type f -name 'SilkSong_CHT_linux' -exec zip -j SilkSong_CHT-Linux.zip {} +
 
       - name: Create Release
         uses: softprops/action-gh-release@v2
@@ -83,8 +83,8 @@ jobs:
           name: Release ${{ github.event.inputs.version }}
           body: 更新補丁邏輯 使用前請使用舊版還原備份 以確保沒有問題。
           files: |
-            dist/SkilSong_CHT-Windows.zip
-            dist/SkilSong_CHT-macOS.zip
-            dist/SkilSong_CHT-Linux.zip
+            dist/SilkSong_CHT-Windows.zip
+            dist/SilkSong_CHT-macOS.zip
+            dist/SilkSong_CHT-Linux.zip
 
 

--- a/README.md
+++ b/README.md
@@ -29,19 +29,19 @@
     * **Linux**: 通常是 `.../steamapps/common/Hollow Knight Silksong/`
 
 3.  **執行工具**：
-    * **Windows**: 直接雙擊 `SkilSong_CHT_win.exe` 執行。程式會自動請求管理員權限。
+    * **Windows**: 直接雙擊 `SilkSong_CHT_win.exe` 執行。程式會自動請求管理員權限。
     * **macOS / Linux**: 開啟終端機 (Terminal)，並切換到遊戲根目錄。
         * 首先，賦予檔案執行權限 (此步驟只需操作一次)：
             ```bash
-            chmod +x ./SkilSong_CHT_mac
+            chmod +x ./SilkSong_CHT_mac
             ```
-            *(若是 Linux 系統，請將指令中的 `SkilSong_CHT_mac` 改為 `SkilSong_CHT_linux`)*
+            *(若是 Linux 系統，請將指令中的 `SilkSong_CHT_mac` 改為 `SilkSong_CHT_linux`)*
 
         * 然後，執行程式：
             ```bash
-            ./SkilSong_CHT_mac
+            ./SilkSong_CHT_mac
             ```
-            *(同樣，Linux 用戶請執行 `./SkilSong_CHT_linux`)*
+            *(同樣，Linux 用戶請執行 `./SilkSong_CHT_linux`)*
 
 5.  **依照選單操作**：
     * 執行後會出現功能選單，輸入 `1` 即可開始繁體中文化處理。


### PR DESCRIPTION
- Corrected the executable names in the build configuration for Windows, macOS, and Linux.
- Updated the README to reflect the new executable names for user instructions.

---

修正 typo SkilSong